### PR TITLE
Fix batch moving of rows in NSTableView

### DIFF
--- a/Sources/Extensions/AppKitExtension.swift
+++ b/Sources/Extensions/AppKitExtension.swift
@@ -73,16 +73,24 @@ public extension NSTableView {
                 removeRows(at: IndexSet(changeset.elementDeleted.map { $0.element }), withAnimation: deleteRowsAnimation())
             }
 
-            if !changeset.elementInserted.isEmpty {
-                insertRows(at: IndexSet(changeset.elementInserted.map { $0.element }), withAnimation: insertRowsAnimation())
-            }
-
             if !changeset.elementUpdated.isEmpty {
                 reloadData(forRowIndexes: IndexSet(changeset.elementUpdated.map { $0.element }), columnIndexes: IndexSet(0..<tableColumns.count))
             }
 
-            for (source, target) in changeset.elementMoved {
-                moveRow(at: source.element, to: target.element)
+            if !changeset.elementMoved.isEmpty {
+                let insertionIndices = IndexSet(changeset.elementInserted.map { $0.element })
+                var movedSourceIndices = IndexSet()
+
+                for (source, target) in changeset.elementMoved {
+                    let sourceElementOffset = movedSourceIndices.count(in: source.element...)
+                    let targetElementOffset = insertionIndices.count(in: 0..<target.element)
+                    moveRow(at: source.element + sourceElementOffset, to: target.element - targetElementOffset)
+                    movedSourceIndices.insert(source.element)
+                }
+            }
+
+            if !changeset.elementInserted.isEmpty {
+                insertRows(at: IndexSet(changeset.elementInserted.map { $0.element }), withAnimation: insertRowsAnimation())
             }
 
             endUpdates()


### PR DESCRIPTION
`NSTableView` doesn't support batch updating so every change (insert, delete, move) may alter its row indexes, making it difficult to apply moves generated from a `StagedChangeset` unless indexes are corrected accordingly and it is ensured that inserts are always performed after any moves.

## Checklist
- [ ] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [ ] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
